### PR TITLE
refactor: Refactor Idling Resource Integration

### DIFF
--- a/app/src/main/java/droiddevelopers254/droidconke/utils/coroutines.kt
+++ b/app/src/main/java/droiddevelopers254/droidconke/utils/coroutines.kt
@@ -1,0 +1,19 @@
+package droiddevelopers254.droidconke.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+fun CoroutineScope.launchIdling(
+        context: CoroutineContext = EmptyCoroutineContext,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        block: suspend CoroutineScope.() -> Unit
+): Job {
+    EspressoIdlingResource.increment()
+    val job = this.launch(context, start, block)
+    job.invokeOnCompletion { EspressoIdlingResource.decrement() }
+    return job
+}

--- a/app/src/main/java/droiddevelopers254/droidconke/viewmodels/AboutDetailsViewModel.kt
+++ b/app/src/main/java/droiddevelopers254/droidconke/viewmodels/AboutDetailsViewModel.kt
@@ -5,9 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import droiddevelopers254.droidconke.datastates.AboutDetailsState
 import droiddevelopers254.droidconke.repository.AboutDetailsRepo
-import droiddevelopers254.droidconke.utils.EspressoIdlingResource
+import droiddevelopers254.droidconke.utils.launchIdling
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 
 class AboutDetailsViewModel(private val aboutDetailsRepo: AboutDetailsRepo) : ViewModel() {
     private val detailsStateMediatorLiveData: MutableLiveData<AboutDetailsState> = MutableLiveData()
@@ -16,11 +15,9 @@ class AboutDetailsViewModel(private val aboutDetailsRepo: AboutDetailsRepo) : Vi
         get() = detailsStateMediatorLiveData
 
     fun fetchAboutDetails(aboutType: String) {
-        EspressoIdlingResource.increment()
-        val job = GlobalScope.launch {
+        GlobalScope.launchIdling {
             val state = aboutDetailsRepo.getAboutDetails(aboutType)
             detailsStateMediatorLiveData.postValue(state)
         }
-        job.invokeOnCompletion { EspressoIdlingResource.decrement() }
     }
 }


### PR DESCRIPTION
This commit refactors the IdlingResource integration into an extension.
This way in order to make use of idling resources with coroutines, one
just has to call:
`GlobalScope.launchIdling{...}`